### PR TITLE
fix: run skipped tests in nested suites

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,5 +51,5 @@ function rmNotPending(suite) {
 
     suite.suites.forEach(rmNotPending);
     suite.tests = suite.tests.filter((t) => t.wasPending);
-    suite.suites = suite.suites.filter((s) => !_.isEmpty(s.tests));
+    suite.suites = suite.suites.filter((s) => !_.isEmpty(s.tests) || !_.isEmpty(s.suites));
 }

--- a/test/index.js
+++ b/test/index.js
@@ -206,6 +206,22 @@ describe('plugin', () => {
             });
         });
 
+        it('should leave pending tests which are nested in several suites', () => {
+            const tree = mkTree({
+                someSuite: {
+                    anotherSuite: ['pending test in nested suite']
+                }
+            });
+
+            applyPlugin_(tree);
+
+            assert.deepEqual(treeToObj(tree), {
+                someSuite: {
+                    anotherSuite: ['pending test in nested suite']
+                }
+            });
+        });
+
         it('should enable pending suites and tests', () => {
             const tree = mkTree({
                 pendingSuite: ['foo test'],


### PR DESCRIPTION
```
describe('Suite', () => {
    describe('Nested suite', () => {
        hermione.skip.in(/.*/, 'reason');
        it('some test', function() {
            
        });
    });
});
```

In this case plugin will not run the test.

сс @j0tunn @sipayRT @DudaGod 